### PR TITLE
regexps for matching messages

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,17 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
+  {
+    "name": "Launch test function",
+    "type": "go",
+    "request": "launch",
+    "mode": "test",
+    "program": "${workspaceFolder}",
+    "args": [
+      // "-test.run",
+      // "MyTestFunction"
+    ]
+  },
   
     {
       "name": "Launch",

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type Autorole struct {
 	Message string `yaml:"message"`
 	Role    string `yaml:"role"`
 	Emoji   string `yaml:"emoji"`
+	Regexp  string `yaml:"regexp,omitempty"`
 }
 
 func parseFlags() *Config {

--- a/discord_test.go
+++ b/discord_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
@@ -66,7 +67,7 @@ func TestFindMessageInternal(t *testing.T) {
 		},
 	}
 
-	result := findMessageInternal(messages, "test content")
+	result := findMessageInternal(messages, nil, "test content")
 
 	assert.Equalf(t, expected, result, "Got %s expected %s", result, expected)
 }
@@ -84,9 +85,31 @@ func TestFindMessageInternalNegtive(t *testing.T) {
 		},
 	}
 
-	result := findMessageInternal(messages, "three")
+	result := findMessageInternal(messages, nil, "three")
 
 	assert.Equalf(t, expected, result, "Got %s expected %s", result, expected)
+}
+
+func TestFindMessageInternalRegexp(t *testing.T) {
+
+	messages := []*discordgo.Message{
+		{
+			ID:      "1",
+			Content: "one",
+		},
+		{
+			ID:      "2",
+			Content: "two secret words",
+		},
+	}
+	var expected *discordgo.Message = messages[1]
+	regexpNeedle := regexp.MustCompile(".*secret.*")
+
+	result := findMessageInternal(messages, regexpNeedle, "three")
+
+	assert.NotNil(t, result)
+	assert.Equal(t, "2", result.ID)
+	assert.Equal(t, expected, result)
 }
 
 func TestFindAutoroles(t *testing.T) {

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -7,3 +7,8 @@ autoroles:
   message: "Add 👍 reaction to this message to obtain role test-autorole. Add 🍺 reaction to obtain test-autorole-beer role. Remove your reaction to have role removed."
   role: test-autorole-beer
   emoji: 🍺
+- channel: "autorole-channel"
+  message: "Add 🔥 reaction to this message to obtain role test-autorole-fire. New content"
+  role: test-autorole-fire
+  regexp: "^Add 🔥 reaction.*"
+  emoji: 🔥

--- a/setup.go
+++ b/setup.go
@@ -58,6 +58,14 @@ func setupAutorole(session *discordgo.Session, guildId string, autorole *Autorol
 		}
 	} else {
 		log.Infof("Message %s found in channel %s in guild %s", message.ID, channel.Name, guildId)
+		if message.Content != autorole.Message {
+			log.Infof("Message content different - needs update.")
+			message, err = session.ChannelMessageEdit(channel.ID, message.ID, autorole.Message)
+			if err != nil {
+				log.Errorf("Error updating message %s in channel %s in guild %s: %s", message.ID, autorole.Channel, guildId, err)
+				return err
+			}
+		}
 	}
 
 	if !message.Pinned {


### PR DESCRIPTION
Use regexps to match existing messages, so the contents of existing messages can be modified. 